### PR TITLE
make labels configurable

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,8 @@
 {
   "env": {
-    "browser": true,
-    "commonjs": true,
+    "node": true,
     "es6": true,
-    "jest": true
+    "mocha": true
   },
   "extends": "eslint:recommended",
   "globals": {
@@ -13,5 +12,8 @@
   "parserOptions": {
     "ecmaVersion": 2018
   },
-  "rules": {}
+  "rules": {
+    "indent": ["error", 2, {"SwitchCase": 1}],
+    "no-trailing-spaces": "warn"
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 node_modules
 .nyc_output
 coverage

--- a/README.md
+++ b/README.md
@@ -70,14 +70,32 @@ This plugin is configurable using the `kuzzlerc` Kuzzle configuration file.
   "plugins": {
     "kuzzle-plugin-prometheus": {
       "syncInterval": 7500,
-      "systemMetricsInterval": 5000
+      "collectSystemMetrics": true,
+      "systemMetricsInterval": 5000,
+      "labels": {
+        "common": [
+          "nodeHost",
+          "nodeMAC",
+          "nodeIP"
+        ],
+        "kuzzle": [
+          "controller",
+          "action",
+          "event",
+          "status",
+          "protocol"
+        ]
+      }
     }
   }
 ```
 
-The two available options are:
 * `syncInterval`: Time interval in __milliseconds__ between two synchronizations with Redis.
+* `collectSystemMetrics`: If set to true (default), collects system metrics.
 * `systemMetricsInterval`: Time interval in __milliseconds__ between two system metrics polling.
+* `labels`:
+  * `common`: An array of labels added to every metrics, defaults to `['nodeHost', 'nodeMAC', 'nodeIP']`
+  * `kuzzle`: 
 
 #### Prometheus
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ This plugin is configurable using the `kuzzlerc` Kuzzle configuration file.
           "controller",
           "action",
           "event",
-          "status",
-          "protocol"
+          "protocol",
+          "status"
         ]
       }
     }
@@ -95,7 +95,7 @@ This plugin is configurable using the `kuzzlerc` Kuzzle configuration file.
 * `systemMetricsInterval`: Time interval in __milliseconds__ between two system metrics polling.
 * `labels`:
   * `common`: An array of labels added to every metrics, defaults to `['nodeHost', 'nodeMAC', 'nodeIP']`
-  * `kuzzle`: 
+  * `kuzzle`: An array of Kuzzle metrics to collect, defaults to `['controller', 'action', 'event', 'protocol', 'status']`
 
 #### Prometheus
 

--- a/demo/kuzzlerc
+++ b/demo/kuzzlerc
@@ -17,7 +17,22 @@
     },
     "kuzzle-plugin-prometheus": {
       "syncInterval": 5000,
-      "systemMetricsInterval": 5000
+      "collectSystemMetrics": true,
+      "systemMetricsInterval": 5000,
+      "labels": {
+        "common": [
+          "nodeHost",
+          "nodeMAC",
+          "nodeIP"
+        ],
+        "kuzzle": [
+          "controller",
+          "action",
+          "event",
+          "protocol",
+          "status"
+        ]
+      }
     }
   },
   "services": {

--- a/lib/PrometheusPlugin.js
+++ b/lib/PrometheusPlugin.js
@@ -104,7 +104,7 @@ class PrometheusPlugin {
    * @param {KuzzlePluginContext} context
    */
   async init(config, context) {
-    Object.assign(this.config.labels, config.labels || {});
+    Object.assign(this.config.labels, config.labels);
     delete config.labels;
     Object.assign(this.config, config);
 

--- a/lib/PrometheusPlugin.js
+++ b/lib/PrometheusPlugin.js
@@ -20,7 +20,8 @@
  */
 'use strict';
 
-const os = require('os'),
+const
+  os = require('os'),
   Prometheus = require('prom-client');
 
 /**
@@ -48,7 +49,22 @@ class PrometheusPlugin {
   constructor() {
     this.config = {
       syncInterval: 7500,
-      systemMetricsInterval: 5000
+      collectSystemMetrics: true,
+      systemMetricsInterval: 5000,
+      labels: {
+        common: [
+          'nodeHost',
+          'nodeMAC',
+          'nodeIP'
+        ],
+        kuzzle: [
+          'controller',
+          'action',
+          'event',
+          'protocol',
+          'status'
+        ]
+      }
     };
 
     this.controllers = {
@@ -65,6 +81,20 @@ class PrometheusPlugin {
         action: 'metrics'
       }
     ];
+
+    this.hostname = os.hostname();
+
+    this._mac = null;
+    this._ip = null;
+  }
+
+
+  get MAC() {
+    return this._mac;
+  }
+
+  get IP() {
+    return this._ip;
   }
 
   /**
@@ -74,33 +104,68 @@ class PrometheusPlugin {
    * @param {KuzzlePluginContext} context
    */
   async init(config, context) {
-    this.config = { ...this.config, ...config };
+    Object.assign(this.config.labels, config.labels || {});
+    delete config.labels;
+    Object.assign(this.config, config);
+
     this.context = context;
 
-    /**
-     * Using MAC address to generate Kuzzle Cluster node
-     * specific Redis key. This can be spoofed but
-     * if this the case, falsified Prometheus metrics are
-     * not your main problem.
-     */
-    this.hostname = os.hostname();
-    this.MAC = await promisify(require('macaddress').one)();
-    this.IP = getIPFromMAC(this.MAC);
+    this._mac = await promisify(require('macaddress').one)();
+    this._ip = getIPFromMAC(this.MAC);
     this.key = `{kuzzle_prometheus}-${this.hostname}_${this.nodeMAC}_${this.IP}`;
 
     this.registry = Prometheus.Registry.globalRegistry;
-    this.registry.setDefaultLabels({
-      nodeHost: this.hostname,
-      nodeMAC: this.MAC,
-      nodeIP: this.IP
-    });
+
+    if (!Array.isArray(this.config.labels.common)) {
+      throw new Error(`[prometheus plugin] Configuration error: Expected 'labels.common' to be an array, ${typeof this.config.labels.common} received.`);
+    }
+
+    // default labels
+    const labels = {};
+    for (const label of this.config.labels.common) {
+      switch (label) {
+        case 'nodeHost':
+          labels[label] = this.hostname;
+          break;
+        case 'nodeMAC':
+          labels[label] = this.MAC;
+          break;
+        case 'nodeIP':
+          labels[label] = this.IP;
+          break;
+        default:
+          throw new Error(`[prometheus plugin] Configuration error: Invalid common label ${label}, should be one of [nodeHost, nodeMAC, nodeIP]`);
+      }
+    }
+    if (this.config.labels.common.length > 0) {
+      this.registry.setDefaultLabels(labels);
+    }
+
+    // kuzzle labels checks
+    if (!Array.isArray(this.config.labels.kuzzle)) {
+      throw new Error(`[prometheus plugin] Configuration error: Expected 'labels.kuzzle' to be an array, ${typeof this.config.labels.kuzzle} received`);
+    }
+    if (this.config.labels.kuzzle.length === 0) {
+      throw new Error('[prometheus plugin] Configuration error: \'labels.kuzzle\' cannot be empty.');
+    }
+    for (const label of this.config.labels.kuzzle) {
+      if (![
+        'controller',
+        'action',
+        'event',
+        'protocol',
+        'status'
+      ].includes(label)) {
+        throw new Error(`[prometheus plugin] Configuration error: Invalid kuzzle label ${label}, should be one of [controller, action, event, protocol, status]`);
+      }
+    }
 
     this.kuzzleMetrics = {
       requests: new Prometheus.Histogram({
         name: `kuzzle_requests`,
         help: `Kuzzle monitoring succeeded requests`,
         buckets: Prometheus.exponentialBuckets(0.0001, 1.5, 36),
-        labelNames: ['controller', 'action', 'event', 'status', 'protocol']
+        labelNames: this.config.labels.kuzzle
       }),
       rooms: new Prometheus.Gauge({
         name: `kuzzle_active_rooms`,
@@ -115,10 +180,12 @@ class PrometheusPlugin {
       'request:onError': this.recordRequests.bind(this)
     };
 
-    this.systemMetricsJob = Prometheus.collectDefaultMetrics({
-      register: this.register,
-      timeout: this.config.systemMetricsInterval
-    });
+    if (this.config.collectSystemMetrics) {
+      this.systemMetricsJob = Prometheus.collectDefaultMetrics({
+        register: this.register,
+        timeout: this.config.systemMetricsInterval
+      });
+    }
 
     this.syncJob = setInterval(
       () => this.pushRegistry(),
@@ -154,21 +221,37 @@ class PrometheusPlugin {
    * @param {String}  event
    */
   recordRequests(request, event) {
-    if (
-      request.input.controller !== 'kuzzle-plugin-prometheus/prometheus' &&
-      request.input.action !== 'metrics'
+    if ( request.input.controller === 'kuzzle-plugin-prometheus/prometheus'
+      && request.input.action === 'metrics'
     ) {
-      this.kuzzleMetrics.requests.observe(
-        {
-          controller: request.input.controller,
-          action: request.input.action,
-          event,
-					protocol: request.context.connection.protocol,
-					status: request.status
-        },
-        Date.now() - request.timestamp
-      );
+      return;
     }
+
+    const data = {};
+    for (const label of this.config.labels.kuzzle) {
+      switch (label) {
+        case 'controller':
+          data.controller = request.input.controller;
+          break;
+        case 'action':
+          data.action = request.input.action;
+          break;
+        case 'event':
+          data.event = event;
+          break;
+        case 'protocol':
+          data.protocol = request.context.connection.protocol;
+          break;
+        case 'status':
+          data.status = request.status;
+          break;
+      }
+    }
+
+    this.kuzzleMetrics.requests.observe(
+      data,
+      Date.now() - request.timestamp
+    );
   }
 
   /**
@@ -229,8 +312,7 @@ class PrometheusPlugin {
     const remoteRegisters =
       keys.length !== 0
         ? (await this.context.accessors.sdk.ms.mget(keys)).map(r =>
-            JSON.parse(r)
-          )
+          JSON.parse(r) )
         : [];
     return Prometheus.AggregatorRegistry.aggregate(
       remoteRegisters.concat([this.registry.getMetricsAsJSON()])

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,14 +20,8 @@
  */
 'use strict';
 
-let PrometheusPlugin;
+const semver = require('semver');
 
-try {
-  // Try to load the es6 version
-  PrometheusPlugin = require('./PrometheusPlugin');
-} catch (e) {
-  // Falling back to es5 version
-  PrometheusPlugin = require('../build/PrometheusPlugin');
-}
-
-module.exports = PrometheusPlugin;
+module.exports = semver.satisfies(process.version, '>= 8.0.0')
+  ? require('./PrometheusPlugin')
+  : require('../build/PrometheusPlugin');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2780,9 +2780,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lolex": {
       "version": "4.1.0",
@@ -4612,9 +4612,9 @@
       "dev": true
     },
     "semver": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.2.tgz",
-      "integrity": "sha512-z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "set-value": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -39,16 +39,16 @@
     "sinon": "^7.2.3"
   },
   "dependencies": {
-    "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.4",
+    "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
     "@babel/plugin-transform-runtime": "^7.4.4",
-    "babel-plugin-transform-util-promisify": "^0.2.2",
     "@babel/preset-env": "^7.4.4",
     "@babel/runtime": "^7.4.4",
-    "semver": "^6.0.0",
+    "babel-plugin-transform-util-promisify": "^0.2.2",
     "macaddress": "^0.2.9",
-    "prom-client": "^11.3.0"
+    "prom-client": "^11.3.0",
+    "semver": "^6.3.0"
   },
   "maintainers": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-prometheus",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Kuzzle plugin: monitoring Kuzzle using Prometheus",
   "main": "lib/index.js",
   "scripts": {

--- a/test/mocks/context.mock.js
+++ b/test/mocks/context.mock.js
@@ -1,4 +1,4 @@
-const 
+const
   RequestMock = require('./request.mock'),
   KuzzleError = require('kuzzle-common-objects').error,
   sinon = require('sinon');

--- a/test/mocks/request.mock.js
+++ b/test/mocks/request.mock.js
@@ -8,9 +8,7 @@ class RequestMock {
   }
 
   init(args) {
-    Object.keys(args).forEach((key) => {
-      this[key] = args[key];
-    });
+    Object.assign(this, args);
   }
 }
 


### PR DESCRIPTION
Make metrics configurable:

* system metrics can be disabled by setting `collectSystemMetrics` to `false`
* default labels can be defined in `labels.common` or even disabled when given an empty array
* kuzzle request metrics to collect can be defined in `labels.kuzzle`