### PR TITLE
[Hotfix] Fiw wrong context on hook handlers

### DIFF
--- a/lib/PrometheusPlugin.ts
+++ b/lib/PrometheusPlugin.ts
@@ -90,12 +90,12 @@ export class PrometheusPlugin extends Plugin {
     };
 
     this.hooks = {
-      'connection:new': this.prometheusController.recordConnections.bind(this),
-      'connection:remove': this.prometheusController.recordConnections.bind(this),
-      'core:hotelClerk:addSubscription': this.prometheusController.recordRooms.bind(this),
-      'core:hotelClerk:removeRoomForCustomer': this.prometheusController.recordRooms.bind(this),
-      'request:onSuccess': this.prometheusController.recordRequests.bind(this),
-      'request:onError': this.prometheusController.recordRequests.bind(this)
+      'connection:new': this.prometheusController.recordConnections.bind(this.prometheusController),
+      'connection:remove': this.prometheusController.recordConnections.bind(this.prometheusController),
+      'core:hotelClerk:addSubscription': this.prometheusController.recordRooms.bind(this.prometheusController),
+      'core:hotelClerk:removeRoomForCustomer': this.prometheusController.recordRooms.bind(this.prometheusController),
+      'request:onSuccess': this.prometheusController.recordRequests.bind(this.prometheusController),
+      'request:onError': this.prometheusController.recordRequests.bind(this.prometheusController)
     };
   }
 }

--- a/lib/controllers/PrometheusController.ts
+++ b/lib/controllers/PrometheusController.ts
@@ -37,8 +37,8 @@ export class PrometheusController {
 
   /**
    * PrometheusController constructor
-   * @param config 
-   * @param context 
+   * @param config
+   * @param context
    */
   constructor (config: JSONObject, context: PluginContext) {
     this.config = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-prometheus",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-prometheus",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Kuzzle plugin: monitoring Kuzzle using Prometheus",
   "author": {
     "name": "The Kuzzle Team <support@kuzzle.io>"


### PR DESCRIPTION
## Description

Hooks handlers were bound to the `PrometheusPlugin` instance instead of the `PrometheusController` instance